### PR TITLE
add minimal UIBKExperimentalPlan entry referencing arbitrary UIBKSamples

### DIFF
--- a/src/nomad_uibk_plugin/schema_packages/sample.py
+++ b/src/nomad_uibk_plugin/schema_packages/sample.py
@@ -5,8 +5,16 @@ from nomad.datamodel.data import (
     ArchiveSection,
     EntryData,
 )
-from nomad.datamodel.metainfo.annotations import ELNAnnotation, ELNComponentEnum
-from nomad.datamodel.metainfo.basesections import CompositeSystem, SectionReference
+from nomad.datamodel.metainfo.annotations import (
+    ELNAnnotation,
+    ELNComponentEnum,
+    SectionProperties,
+)
+from nomad.datamodel.metainfo.basesections import (
+    CompositeSystem,
+    Entity,
+    SectionReference,
+)
 from nomad.datamodel.metainfo.plot import PlotlyFigure, PlotSection
 from nomad.metainfo import Quantity, SchemaPackage, Section, SubSection
 from nomad_pvcomb.schema_packages.activities import Object
@@ -242,6 +250,43 @@ class UIBKSampleReference(Object):
         # Update name
         if self.reference and self.name is None:
             self.name = self.reference.name
+
+
+class UIBKExperimentalPlan(Entity, EntryData):
+    """
+    Section that describes experimental plans.
+    """
+
+    # For now, only contains references to samples, can be extended
+    # in the future to add info from xls files for the experimental plan
+    m_def = Section(
+        categories=[UIBKCategory],
+        label='UIBK Experimental Plan',
+        a_eln=ELNAnnotation(
+            properties=SectionProperties(
+                order=[
+                    'name',
+                    'datetime',
+                    'lab_id',
+                    'description',
+                    'sample_reference',
+                ]
+            )
+        ),
+    )
+
+    sample_reference = Quantity(
+        type=UIBKSample,
+        shape=['*'],
+        description='Reference to an UIBK sample that belongs to the experiment plan.',
+        a_eln=ELNAnnotation(
+            component='ReferenceEditQuantity',
+            label='link to sample',
+        ),
+    )
+
+    def normalize(self, archive: 'EntryArchive', logger: 'BoundLogger'):
+        super().normalize(archive, logger)
 
 
 m_package.__init_metainfo__()


### PR DESCRIPTION
The new entry looks like this:
<img width="1428" height="1708" alt="Screenshot from 2026-03-18 16-42-08" src="https://github.com/user-attachments/assets/f5cbac62-a40e-416c-a1de-2bcfb305ad44" />

Existing samples (which user has rights to access) can be added via small "pencil" button next to the empty `link to sample` field - this dialog will appear:
<img width="2860" height="1783" alt="Screenshot from 2026-03-18 16-42-37" src="https://github.com/user-attachments/assets/444e59ee-19c3-43de-b075-8abaeb508ed7" />

New empty sample entry can be created by choosing small "plus" button next to the empty "link to sample" field:
<img width="2860" height="1783" alt="Screenshot from 2026-03-18 16-42-49" src="https://github.com/user-attachments/assets/297cd426-42c4-43ec-afdc-af739eb4a434" />
