### PR TITLE
fixing parameter mame that does not match nomad model

### DIFF
--- a/src/nomad_uibk_plugin/parsers/__init__.py
+++ b/src/nomad_uibk_plugin/parsers/__init__.py
@@ -17,7 +17,7 @@ xrfparser = XRFParserEntryPoint(
     name='XRFParser',
     description='XRF Parser for UIBK .txt files.',
     mainfile_name_re=r'.*\.txt',
-    mainfile_content_re=r'PositionType\s+Application\s+Sample\s+name\s+Date\s+\n[A-Z0-9-]+\s+Quant\s+analysis',
+    mainfile_contents_re=r'PositionType\s+Application\s+Sample\s+name\s+Date\s+\n[A-Z0-9-]+\s+Quant\s+analysis',
 )
 
 # # Microcell parser entry points
@@ -37,7 +37,7 @@ xrfparser = XRFParserEntryPoint(
 #     name='EBICParser',
 #     description='Parser for EBIC tiff files.',
 #     mainfile_name_re='.*\.(tif|tiff)',
-#     mainfile_content_re='pointelectronic\.com',
+#     mainfile_contents_re='pointelectronic\.com',
 # )
 
 


### PR DESCRIPTION
The parameter in our XRF-file detection does not match the model in the NOMAD plugin. I've ran git log -L against our __ini__.py and the corresponding [line in NOMAD](https://github.com/FAIRmat-NFDI/nomad/blob/469b816832fd511f8cc93156333af8b6f4dd182d/nomad/config/models/plugins.py#L173) and I don't see how that was ever working or is working without this PR.